### PR TITLE
Exclude StyleCopAnalyzer from nuget package

### DIFF
--- a/RangeTree/RangeTree.csproj
+++ b/RangeTree/RangeTree.csproj
@@ -32,7 +32,7 @@ For a full list changes at https://github.com/mbuchetics/RangeTree/releases</Pac
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
After removing the nuspec files, the analyzer got included as a dependency in the nuget packages.