### PR TITLE
Fix Comparer issues

### DIFF
--- a/RangeTree/RangeTree.cs
+++ b/RangeTree/RangeTree.cs
@@ -33,7 +33,7 @@ namespace RangeTree
         /// </summary>
         public RangeTree(IComparer<TKey> comparer)
         {
-            this.comparer = comparer;
+            this.comparer = comparer ?? Comparer<TKey>.Default;
             isInSync = true;
             root = new RangeTreeNode<TKey, TValue>(this.comparer);
             items = new List<RangeValuePair<TKey, TValue>>();
@@ -57,7 +57,7 @@ namespace RangeTree
 
         public void Add(TKey from, TKey to, TValue value)
         {
-            if (comparer.Compare(from, to) == 1)
+            if (comparer.Compare(from, to) > 0)
                 throw new ArgumentOutOfRangeException($"{nameof(from)} cannot be larger than {nameof(to)}");
 
             isInSync = false;
@@ -72,7 +72,7 @@ namespace RangeTree
 
         public void Remove(IEnumerable<TValue> items)
         {
-            isInSync = false;            
+            isInSync = false;
             this.items = this.items.Where(l => !items.Contains(l.Value)).ToList();
         }
 

--- a/RangeTreeTests/ComparerTests.cs
+++ b/RangeTreeTests/ComparerTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+using RangeTree;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RangeTreeTests
+{
+    [TestFixture]
+    public class ComparerTests
+    {
+        [Test]
+        public void AddingAnItem_FromIsLargerThanTo_ShouldThrowException()
+        {
+            var comparer = Comparer<int>.Create((x, y) => x - y);
+            var tree = new RangeTree<int, string>(comparer);
+
+            TestDelegate act = () => tree.Add(2, 0, "FOO");
+
+            Assert.Throws<ArgumentOutOfRangeException>(act);
+        }
+
+        [Test]
+        public void CreatingTreeWithNullComparer_AddingAnItem_ShouldNotThrowException()
+        {
+            var tree = new RangeTree<int, string>(null);
+
+            TestDelegate act = () => tree.Add(0, 1, "FOO");
+
+            Assert.DoesNotThrow(act);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes two cases with comparer:
* A comparer may return any positive value, not just `1`, when `from` is greater than `to`
* Providing a `null` `comparer` would lead to a `NullReferenceException`.