### PR TITLE
Readonly

### DIFF
--- a/RangeTree/RangeTreeNode.cs
+++ b/RangeTree/RangeTreeNode.cs
@@ -11,10 +11,10 @@ namespace RangeTree
     /// </summary>
     internal class RangeTreeNode<TKey, TValue> : IComparer<RangeValuePair<TKey, TValue>>
     {
-        private TKey center;
-        private RangeTreeNode<TKey, TValue> leftNode;
-        private RangeTreeNode<TKey, TValue> rightNode;
-        private RangeValuePair<TKey, TValue>[] items;
+        private readonly TKey center;
+        private readonly RangeTreeNode<TKey, TValue> leftNode;
+        private readonly RangeTreeNode<TKey, TValue> rightNode;
+        private readonly RangeValuePair<TKey, TValue>[] items;
 
         private readonly IComparer<TKey> comparer;
 

--- a/RangeTree/RangeValuePair.cs
+++ b/RangeTree/RangeValuePair.cs
@@ -8,7 +8,7 @@ namespace RangeTree
     /// Both values must be of the same type and comparable.
     /// </summary>
     /// <typeparam name="TKey">Type of the values.</typeparam>
-    public struct RangeValuePair<TKey, TValue> : IEquatable<RangeValuePair<TKey, TValue>>
+    public readonly struct RangeValuePair<TKey, TValue> : IEquatable<RangeValuePair<TKey, TValue>>
     {
         public TKey From { get; }
         public TKey To { get; }


### PR DESCRIPTION
Marking fields and `RangeValuePair` as `readonly` to express intent.
E.g. a `RangeValuePair` should never mutate, as the algorithm relies on sortedness, which might not be preserved if the struct mutates.