### PR TITLE
Fix Min/Max

### DIFF
--- a/RangeTree/RangeTree.cs
+++ b/RangeTree/RangeTree.cs
@@ -14,10 +14,27 @@ namespace RangeTree
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public TKey Max => root.Max;
+        public TKey Max
+        {
+            get
+            {
+                if (!isInSync)
+                    Rebuild();
 
-        public TKey Min => root.Min;
+                return root.Max;
+            }
+        }
 
+        public TKey Min
+        {
+            get
+            {
+                if (!isInSync)
+                    Rebuild();
+
+                return root.Min;
+            }
+        }
 
         public IEnumerable<TValue> Values => items.Select(i => i.Value);
 
@@ -72,7 +89,7 @@ namespace RangeTree
 
         public void Remove(IEnumerable<TValue> items)
         {
-            isInSync = false;            
+            isInSync = false;
             this.items = this.items.Where(l => !items.Contains(l.Value)).ToList();
         }
 

--- a/RangeTree/RangeTreeNode.cs
+++ b/RangeTree/RangeTreeNode.cs
@@ -190,9 +190,9 @@ namespace RangeTree
             get
             {
                 if (leftNode != null)
-                    return leftNode.Max;
+                    return leftNode.Min;
                 else if (items != null)
-                    return items.Max(i => i.From);
+                    return items.Min(i => i.From);
                 else
                     return default(TKey);
             }

--- a/RangeTreeTests/RangeTreeTests.cs
+++ b/RangeTreeTests/RangeTreeTests.cs
@@ -1,0 +1,71 @@
+﻿using NUnit.Framework;
+using RangeTree;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RangeTreeTests
+{
+    [TestFixture]
+    public class RangeTreeTests
+    {
+        [Test]
+        public void GettingMin_InnerItems()
+        {
+            var tree = new RangeTree<int, int>
+            {
+                { 1, 5, -1 },
+                { 2, 5, -1 },
+                { 3, 5, -1 },
+            };
+
+            var min = tree.Min;
+
+            Assert.AreEqual(1, min);
+        }
+
+        [Test]
+        public void GettingMin_LeftRecurse()
+        {
+            var tree = new RangeTree<int, int>
+            {
+                { 1, 2, -1 },
+                { 3, 4, -1 }
+            };
+
+            var min = tree.Min;
+
+            Assert.AreEqual(1, min);
+        }
+
+        [Test]
+        public void GettingMax_InnerItems()
+        {
+            var tree = new RangeTree<int, int>
+            {
+                { 1, 2, -1 },
+                { 1, 3, -1 },
+                { 1, 4, -1 },
+            };
+
+            var max = tree.Max;
+
+            Assert.AreEqual(4, max);
+        }
+
+        [Test]
+        public void GettingMax_RightRecurse()
+        {
+            var tree = new RangeTree<int, int>
+            {
+                { 1, 2, -1 },
+                { 3, 4, -1 },
+                { 5, 6, -1 }
+            };
+
+            var max = tree.Max;
+
+            Assert.AreEqual(6, max);
+        }
+    }
+}


### PR DESCRIPTION
`RangeTreeNode.Min` had what looks like two copy/paste bugs, as it returned the max value.
Furthermore wrong results for both `RangeTree.Min` and `RangeTree.Max` could be returned, as it didn't ensure the tree was in sync.