### PR TITLE
Fixed bug in calculating min/max key values

### DIFF
--- a/IntervalTree/IntervalTree.csproj
+++ b/IntervalTree/IntervalTree.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2;netstandard2.0;net45</TargetFrameworks>
+    <PackageVersion>3.0.1</PackageVersion>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -23,8 +24,8 @@ In computer science, an interval tree is an ordered tree data structure to hold 
     <PackageReleaseNotes>BREAKING CHANGES: Removing RangeTree code after is has been renamed to IntervalTree in version 2.1.0.
 Make sure that you upgrade to version 2.1.0 first and that you have no more errors before upgrading to this version. This version contains no new features, but fixes the misleading name "RangeTree" when in fact it is an Interval tree.
 For a full list changes at https://github.com/mbuchetics/RangeTree/releases</PackageReleaseNotes>
-    <AssemblyVersion>3.0.0</AssemblyVersion>
-    <FileVersion>3.0.0</FileVersion>
+    <AssemblyVersion>3.0.1</AssemblyVersion>
+    <FileVersion>3.0.1</FileVersion>
     <Company>Matthias Buchetics, Alexander Pacha</Company>
   </PropertyGroup>
   

--- a/IntervalTree/IntervalTree.csproj
+++ b/IntervalTree/IntervalTree.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2;netstandard2.0;net45</TargetFrameworks>
-    <PackageVersion>3.0.1</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -24,8 +24,8 @@ In computer science, an interval tree is an ordered tree data structure to hold 
     <PackageReleaseNotes>BREAKING CHANGES: Removing RangeTree code after is has been renamed to IntervalTree in version 2.1.0.
 Make sure that you upgrade to version 2.1.0 first and that you have no more errors before upgrading to this version. This version contains no new features, but fixes the misleading name "RangeTree" when in fact it is an Interval tree.
 For a full list changes at https://github.com/mbuchetics/RangeTree/releases</PackageReleaseNotes>
-    <AssemblyVersion>3.0.1</AssemblyVersion>
-    <FileVersion>3.0.1</FileVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
+    <FileVersion>3.0.0</FileVersion>
     <Company>Matthias Buchetics, Alexander Pacha</Company>
   </PropertyGroup>
   

--- a/IntervalTree/IntervalTreeNode.cs
+++ b/IntervalTree/IntervalTreeNode.cs
@@ -173,8 +173,8 @@ namespace IntervalTree
             return fromComp;
         }
 
-        public TKey Max { get; private set; } = default(TKey);
+        public TKey Max { get; }
 
-        public TKey Min { get; private set; } = default(TKey);
+        public TKey Min { get; }
     }
 }

--- a/IntervalTree/IntervalTreeNode.cs
+++ b/IntervalTree/IntervalTreeNode.cs
@@ -48,11 +48,13 @@ namespace IntervalTree
                 endPoints.Add(item.To);
             }
             endPoints.Sort(this.comparer);
-
+            
             // the median is used as center value
             if (endPoints.Count > 0)
             {
+                Min = endPoints[0];
                 center = endPoints[endPoints.Count / 2];
+                Max = endPoints[endPoints.Count - 1];
             }
 
             var inner = new List<RangeValuePair<TKey, TValue>>();
@@ -171,30 +173,8 @@ namespace IntervalTree
             return fromComp;
         }
 
-        public TKey Max
-        {
-            get
-            {
-                if (rightNode != null)
-                    return rightNode.Max;
-                else if (items != null)
-                    return items.Max(i => i.To);
-                else
-                    return default(TKey);
-            }
-        }
+        public TKey Max { get; private set; } = default(TKey);
 
-        public TKey Min
-        {
-            get
-            {
-                if (leftNode != null)
-                    return leftNode.Min;
-                else if (items != null)
-                    return items.Min(i => i.From);
-                else
-                    return default(TKey);
-            }
-        }
+        public TKey Min { get; private set; } = default(TKey);
     }
 }

--- a/IntervalTreeTests/IntervalTreeTests.cs
+++ b/IntervalTreeTests/IntervalTreeTests.cs
@@ -64,5 +64,36 @@ namespace IntervalTreeTests
 
             Assert.That(max, Is.EqualTo(6));
         }
+
+        [Test]
+        public void GettingMin_Mixed()
+        {
+            var tree = new IntervalTree<int, int>
+            {
+                { 2, 3, -1 },
+                { 8, 9, -1 },
+                { 1, 10, -1 },
+            };
+
+            var min = tree.Min;
+
+            Assert.That(min, Is.EqualTo(1));
+        }
+        
+        [Test]
+        public void GettingMax_Mixed()
+        {
+            var tree = new IntervalTree<int, int>
+            {
+                { 1, 10, -1 },
+                { 2, 3, -1 },
+                { 4, 5, -1 },
+                { 8, 9, -1 },
+            };
+
+            var max = tree.Max;
+
+            Assert.That(max, Is.EqualTo(10));
+        }
     }
 }


### PR DESCRIPTION
the min & max key values aren't calculated anymore on the fly, they are set on the root node during initialization without any extra overhead.