### PR TITLE
Add queries that return a single value.

### DIFF
--- a/IntervalTree/IIntervalTree.cs
+++ b/IntervalTree/IIntervalTree.cs
@@ -22,9 +22,19 @@ namespace IntervalTree
         int Count { get; }
 
         /// <summary>
+        /// Performs a point query with a single value. One item with an overlapping ranges is returned.
+        /// </summary>
+        TValue QueryOne(TKey value);
+
+        /// <summary>
         /// Performs a point query with a single value. All items with overlapping ranges are returned.
         /// </summary>
         IEnumerable<TValue> Query(TKey value);
+
+        /// <summary>
+        /// Performs a range query. One item with an overlapping range is returned.
+        /// </summary>
+        TValue QueryOne(TKey from, TKey to);
 
         /// <summary>
         /// Performs a range query. All items with overlapping ranges are returned.

--- a/IntervalTree/IntervalTree.cs
+++ b/IntervalTree/IntervalTree.cs
@@ -56,12 +56,28 @@ namespace IntervalTree
             items = new List<RangeValuePair<TKey, TValue>>();
         }
 
+        public TValue QueryOne(TKey value)
+        {
+            if (!isInSync)
+                Rebuild();
+
+            return root.QueryOne(value);
+        }
+
         public IEnumerable<TValue> Query(TKey value)
         {
             if (!isInSync)
                 Rebuild();
 
             return root.Query(value);
+        }
+
+        public TValue QueryOne(TKey from, TKey to)
+        {
+            if (!isInSync)
+                Rebuild();
+
+            return root.QueryOne(from, to);
         }
 
         public IEnumerable<TValue> Query(TKey from, TKey to)

--- a/IntervalTree/IntervalTreeNode.cs
+++ b/IntervalTree/IntervalTreeNode.cs
@@ -94,6 +94,40 @@ namespace IntervalTree
 
         /// <summary>
         /// Performs a point query with a single value.
+        /// One item with an overlapping range is returned.
+        /// </summary>
+        public TValue QueryOne(TKey value)
+        {
+            // If the node has items, check for leaves containing the value.
+            if (items != null)
+            {
+                foreach (var o in items)
+                {
+                    if (comparer.Compare(o.From, value) > 0) break;
+                    else if (comparer.Compare(value, o.From) >= 0 && comparer.Compare(value, o.To) <= 0)
+                    {
+                        return o.Value;
+                    }
+                }
+            }
+
+            // go to the left or go to the right of the tree, depending
+            // where the query value lies compared to the center
+            var centerComp = comparer.Compare(value, center);
+            if (leftNode != null && centerComp < 0)
+            {
+                return leftNode.FindOverlap(value);
+            }
+            else if (rightNode != null && centerComp > 0)
+            {
+                return rightNode.FindOverlap(value);
+            }
+
+            return default(TValue);
+        }
+
+        /// <summary>
+        /// Performs a point query with a single value.
         /// All items with overlapping ranges are returned.
         /// </summary>
         public IEnumerable<TValue> Query(TKey value)
@@ -123,6 +157,52 @@ namespace IntervalTree
                 results.AddRange(rightNode.Query(value));
 
             return results;
+        }
+
+        /// <summary>
+        /// Performs a range query.
+        /// One item with an overlapping ranges is returned.
+        /// </summary>
+        public TValue QueryOne(TKey from, TKey to)
+        {
+            // If the node has items, check for leaves intersecting the range.
+            if (items != null)
+            {
+                foreach (var o in items)
+                {
+                    if (comparer.Compare(o.From, to) > 0) break;
+                    else if (comparer.Compare(to, o.From) >= 0 && comparer.Compare(from, o.To) <= 0)
+                    {
+                        return o.Value;
+                    }
+                }
+            }
+
+            // go to the left or go to the right of the tree, depending
+            // where the query value lies compared to the center
+            TValue defaultResult = default(TValue);
+            TValue result;
+
+            if (leftNode != null && comparer.Compare(from, center) < 0)
+            {
+                result = leftNode.FindOverlap(from, to);
+
+                if (!result.Equals(defaultResult))
+                {
+                    return result;
+                }
+            }
+            if (rightNode != null && comparer.Compare(to, center) > 0)
+            {
+                result = rightNode.FindOverlap(from, to);
+
+                if (!result.Equals(defaultResult))
+                {
+                    return result;
+                }
+            }
+
+            return defaultResult;
         }
 
         /// <summary>


### PR DESCRIPTION
Sometimes a user might only be interested in finding a single point of overlap in the interval tree. I've added two QueryOne methods that do just that without the additional overhead of continually searching once at least one value was returned.

There is interest to use this data structure in another project and part of the changes I need to make for it to fit our use case includes the above. I was asked to contribute this code to the project so that we may import it via nuget instead of manually adding the package to the project ourselves.

Please let me know what you think :) 